### PR TITLE
[#159880262]【検証シート】経過日数がNaNになる部分の改善

### DIFF
--- a/app/webroot/js/table_function.js
+++ b/app/webroot/js/table_function.js
@@ -214,8 +214,8 @@ function postToEditAction(controller_name, selectedTd, postValue, __editStarting
             }
 
             $(selectedTd).html(recordtext(textEdited));
-            if (columnName == 'pullrequest_update') {
-                var pullrequestDate = new Date($('#' + id + '-pullrequest_update').text());
+            if (columnName == 'pullrequest') {
+                var pullrequestDate = new Date($('#' + id + '-pullrequest').text());
                 var todayDate = new Date();
 
                 $('#' + id + '-elapsed').html(recordtext(Math.round((todayDate - pullrequestDate)/86400000)));


### PR DESCRIPTION
空欄になっているプルリク更新日のセルをダブルクリックで編集し、空欄のまま確定すると
経過日数がNaNになっていたのを修正しました。